### PR TITLE
Fixes situations where Expires is set in the header but smaller than …

### DIFF
--- a/src/Replicant/FilePair.cs
+++ b/src/Replicant/FilePair.cs
@@ -1,4 +1,4 @@
-﻿using Replicant;
+using Replicant;
 
 [DebuggerDisplay("Content = {Content} | Meta = {Meta}")]
 readonly struct FilePair(string content, string meta)
@@ -24,14 +24,8 @@ readonly struct FilePair(string content, string meta)
 
     public void SetExpiry(DateTimeOffset? expiry)
     {
-        if (expiry == null)
-        {
-            File.SetLastWriteTimeUtc(Content, FileEx.MinFileDate);
-        }
-        else
-        {
-            File.SetLastWriteTimeUtc(Content, expiry.Value.UtcDateTime);
-        }
+        var expiryDate = expiry?.UtcDateTime ?? FileEx.MinFileDate;
+        File.SetLastWriteTimeUtc(Content, expiryDate >= FileEx.MinFileDate ? expiryDate : FileEx.MinFileDate);
     }
 
     public void PurgeItem()


### PR DESCRIPTION
We've encountered cases where the HTTP response header didn't indicate the correct value in Expires, generating a value lower than FileEx.MinFileDate and triggering an exception from File.SetLastWriteTimeUtc method.

`System.ArgumentOutOfRangeException : Not a valid Win32 FileTime.`

This change takes into account this kind of situation, which unfortunately occurs frequently in our project. And we have no control over these files or the server hosting them.

If need be, I can give an example of these URLs privately.


